### PR TITLE
remove overflow-hidden from content preview causing focus ring to be truncated

### DIFF
--- a/src/components/component-preview.tsx
+++ b/src/components/component-preview.tsx
@@ -117,7 +117,7 @@ export function ComponentPreview({
 								</div>
 							}
 						>
-							<div className="w-full max-w-full overflow-hidden">{Preview}</div>
+							<div className="w-full max-w-full">{Preview}</div>
 						</React.Suspense>
 					</div>
 				</TabsContent>


### PR DESCRIPTION
before and after

<img width="984" alt="Screenshot 2025-02-02 at 11 44 35 AM" src="https://github.com/user-attachments/assets/ff5b79a3-5120-440e-abff-ec2bc208f93b" />
<img width="642" alt="Screenshot 2025-02-02 at 11 32 17 AM" src="https://github.com/user-attachments/assets/086f75f2-bd71-4ee2-b4cd-63951f098abc" />
